### PR TITLE
Refactor: Address lint warnings and apply deprecation fixes

### DIFF
--- a/lib/src/core/theme/app_theme.dart
+++ b/lib/src/core/theme/app_theme.dart
@@ -41,11 +41,9 @@ class AppTheme {
       onTertiaryContainer: AppColors.onTertiaryContainerLight,
       error: AppColors.errorColor,
       onError: AppColors.onError,
-      background: AppColors.lightScaffoldBackground, // Or lightBackground
-      onBackground: AppColors.lightText,
-      surface: AppColors.lightSurface,
-      onSurface: AppColors.lightText,
-      surfaceVariant: AppColors.surfaceVariantLight,
+      surface: AppColors.lightScaffoldBackground, // Intended: color from original background
+      onSurface: AppColors.lightText, // Intended: color from original onBackground
+      surfaceContainerHighest: AppColors.surfaceVariantLight, 
       onSurfaceVariant: AppColors.onSurfaceVariantLight,
       outline: AppColors.outlineLight,
       outlineVariant: AppColors.outlineVariantLight,
@@ -146,15 +144,13 @@ class AppTheme {
       onTertiaryContainer: AppColors.onTertiaryContainerDark,
       error: AppColors.errorColor, // Remains the same
       onError: AppColors.onError, // Remains the same
-      background: AppColors.darkScaffoldBackground, // Or darkBackground
-      onBackground: AppColors.darkText,
-      surface: AppColors.darkSurface,
-      onSurface: AppColors.darkText,
-      surfaceVariant: AppColors.surfaceVariantDark,
+      surface: AppColors.darkScaffoldBackground, // Intended: color from original background
+      onSurface: AppColors.darkText, // Intended: color from original onBackground
+      surfaceContainerHighest: AppColors.surfaceVariantDark, 
       onSurfaceVariant: AppColors.onSurfaceVariantDark,
       outline: AppColors.outlineDark,
       outlineVariant: AppColors.outlineVariantDark,
-      shadow: AppColors.shadowColor, // M3 uses less shadow in dark, but we can keep it or use a more subtle one like Colors.black.withOpacity(0.1)
+      shadow: AppColors.shadowColor, // M3 uses less shadow in dark, but we can keep it or use a more subtle one like Colors.black.withAlpha((255 * 0.1).round())
       scrim: Colors.black54, // Default M3 scrim is often a translucent black, darker for dark theme
       inverseSurface: AppColors.lightSurface,
       onInverseSurface: AppColors.lightText,

--- a/lib/src/data/repositories/local/local_hydration_repository.dart
+++ b/lib/src/data/repositories/local/local_hydration_repository.dart
@@ -7,14 +7,14 @@ import 'package:minum/main.dart'; // For logger
 
 // This constant can be defined globally or passed around.
 // It represents the user ID for entries made when not logged in.
-const String GUEST_USER_ID = "local_guest_user";
+const String guestUserId = "local_guest_user";
 
 class LocalHydrationRepository implements HydrationRepository {
   final DatabaseHelper _dbHelper = DatabaseHelper.instance;
 
   @override
   Future<void> addHydrationEntry(String userId, HydrationEntry entry) async {
-    final String effectiveUserId = userId.isEmpty ? GUEST_USER_ID : userId;
+    final String effectiveUserId = userId.isEmpty ? guestUserId : userId;
 
     final HydrationEntry entryToSave = entry.copyWith(
         userId: effectiveUserId,
@@ -31,7 +31,7 @@ class LocalHydrationRepository implements HydrationRepository {
   @override
   Future<void> updateHydrationEntry(String userId, HydrationEntry entry) async {
     int? localIdToUpdate = entry.localDbId;
-    final effectiveUserId = userId.isEmpty ? GUEST_USER_ID : userId; // Ensure effectiveUserId is used
+    final effectiveUserId = userId.isEmpty ? guestUserId : userId; // Ensure effectiveUserId is used
 
     if (localIdToUpdate == null && entry.id != null) {
       // Use effectiveUserId when looking up by Firestore ID
@@ -55,7 +55,7 @@ class LocalHydrationRepository implements HydrationRepository {
   // Updated method signature to match interface (will be HydrationEntry entryToDelete)
   @override
   Future<void> deleteHydrationEntry(String userId, HydrationEntry entryToDelete) async {
-    final effectiveUserId = userId.isEmpty ? GUEST_USER_ID : userId;
+    final effectiveUserId = userId.isEmpty ? guestUserId : userId;
 
     if (entryToDelete.localDbId != null) {
       await _dbHelper.markHydrationEntryAsDeletedByLocalId(entryToDelete.localDbId!);
@@ -76,7 +76,7 @@ class LocalHydrationRepository implements HydrationRepository {
   @override
   Future<HydrationEntry?> getHydrationEntry(String userId, String entryId) async {
     // entryId is assumed to be Firestore ID
-    final effectiveUserId = userId.isEmpty ? GUEST_USER_ID : userId;
+    final effectiveUserId = userId.isEmpty ? guestUserId : userId;
     int? localId = await _dbHelper.getLocalIdFromFirestoreId(entryId, effectiveUserId);
     if(localId != null) {
       return await _dbHelper.getHydrationEntryByLocalId(localId);
@@ -92,7 +92,7 @@ class LocalHydrationRepository implements HydrationRepository {
   @override
   Stream<List<HydrationEntry>> getHydrationEntriesForDateRange(
       String userId, DateTime startDate, DateTime endDate) {
-    final effectiveUserId = userId.isEmpty ? GUEST_USER_ID : userId;
+    final effectiveUserId = userId.isEmpty ? guestUserId : userId;
     logger.d("LocalHydrationRepo: Getting entries for user/scope: $effectiveUserId, range: $startDate - $endDate");
 
     return Stream.fromFuture(
@@ -107,7 +107,7 @@ class LocalHydrationRepository implements HydrationRepository {
   }
 
   Future<List<HydrationEntry>> getUnsyncedNewOrUpdatedEntries(String userId) async {
-    final effectiveUserId = userId.isEmpty ? GUEST_USER_ID : userId;
+    final effectiveUserId = userId.isEmpty ? guestUserId : userId;
     return _dbHelper.getUnsyncedNewOrUpdatedEntries(effectiveUserId);
   }
 
@@ -116,7 +116,7 @@ class LocalHydrationRepository implements HydrationRepository {
   }
 
   Future<List<HydrationEntry>> getDeletedUnsyncedEntries(String userId) async {
-    final effectiveUserId = userId.isEmpty ? GUEST_USER_ID : userId;
+    final effectiveUserId = userId.isEmpty ? guestUserId : userId;
     return _dbHelper.getDeletedUnsyncedEntries(effectiveUserId);
   }
 
@@ -129,12 +129,12 @@ class LocalHydrationRepository implements HydrationRepository {
   }
 
   Future<int?> getLocalIdFromFirestoreId(String firestoreId, String userId) async {
-    final effectiveUserId = userId.isEmpty ? GUEST_USER_ID : userId;
+    final effectiveUserId = userId.isEmpty ? guestUserId : userId;
     return _dbHelper.getLocalIdFromFirestoreId(firestoreId, effectiveUserId);
   }
 
   Future<int> upsertHydrationEntry(HydrationEntry entry, String userId) async {
-    final effectiveUserId = userId.isEmpty ? GUEST_USER_ID : userId;
+    final effectiveUserId = userId.isEmpty ? guestUserId : userId;
     final entryToUpsert = entry.copyWith(userId: effectiveUserId, isSynced: true, isLocallyDeleted: false);
     return _dbHelper.upsertHydrationEntry(entryToUpsert, effectiveUserId);
   }

--- a/lib/src/presentation/providers/hydration_provider.dart
+++ b/lib/src/presentation/providers/hydration_provider.dart
@@ -6,7 +6,7 @@ import 'package:minum/src/data/models/user_model.dart';
 import 'package:minum/src/services/auth_service.dart';
 import 'package:minum/src/services/hydration_service.dart';
 import 'package:minum/main.dart'; // For logger
-import 'package:minum/src/data/repositories/local/local_hydration_repository.dart' show GUEST_USER_ID;
+import 'package:minum/src/data/repositories/local/local_hydration_repository.dart' show guestUserId;
 
 enum HydrationLogStatus { idle, loading, loaded, error }
 enum HydrationActionStatus { idle, processing, success, error }
@@ -54,7 +54,7 @@ class HydrationProvider with ChangeNotifier {
         _currentUserId = newUserId;
         logger.i("HydrationProvider: User changed to ${_currentUserId ?? 'guest'}. Fetching entries for $_selectedDate.");
         _cancelEntriesSubscription();
-        final userIdForFetch = _currentUserId ?? GUEST_USER_ID;
+        final userIdForFetch = _currentUserId ?? guestUserId;
         if (userIdForFetch.isNotEmpty) {
           await fetchHydrationEntriesForDate(_selectedDate);
         } else {
@@ -62,8 +62,8 @@ class HydrationProvider with ChangeNotifier {
           _logStatus = HydrationLogStatus.idle;
           _safeNotifyListeners();
         }
-      } else if (_currentUserId == null && GUEST_USER_ID.isNotEmpty && _dailyEntries.isEmpty && _logStatus == HydrationLogStatus.idle) {
-        _currentUserId = GUEST_USER_ID;
+      } else if (_currentUserId == null && guestUserId.isNotEmpty && _dailyEntries.isEmpty && _logStatus == HydrationLogStatus.idle) {
+        _currentUserId = guestUserId;
         logger.i("HydrationProvider: Initializing for guest user. Fetching entries for $_selectedDate.");
         await fetchHydrationEntriesForDate(_selectedDate);
       }
@@ -84,7 +84,7 @@ class HydrationProvider with ChangeNotifier {
     _selectedDate = normalizedDate;
     logger.i("HydrationProvider: Selected date changed to $_selectedDate.");
     _cancelEntriesSubscription();
-    final userIdForFetch = _currentUserId ?? GUEST_USER_ID;
+    final userIdForFetch = _currentUserId ?? guestUserId;
     if (userIdForFetch.isNotEmpty) {
       await fetchHydrationEntriesForDate(_selectedDate);
     } else {
@@ -96,8 +96,8 @@ class HydrationProvider with ChangeNotifier {
 
   Future<void> fetchHydrationEntriesForDate(DateTime date) async {
     if (_isDisposed) return;
-    final userIdForFetch = _currentUserId ?? GUEST_USER_ID;
-    if (userIdForFetch.isEmpty && userIdForFetch != GUEST_USER_ID) {
+    final userIdForFetch = _currentUserId ?? guestUserId;
+    if (userIdForFetch.isEmpty && userIdForFetch != guestUserId) {
       _logStatus = HydrationLogStatus.idle;
       _dailyEntries = [];
       _safeNotifyListeners();
@@ -136,8 +136,8 @@ class HydrationProvider with ChangeNotifier {
 
   Stream<List<HydrationEntry>> getEntriesForDateRangeStream(String userId, DateTime startDate, DateTime endDate) {
     if (_isDisposed) return Stream.value([]);
-    final userIdForFetch = userId.isEmpty ? GUEST_USER_ID : userId;
-    if (userIdForFetch.isEmpty && userIdForFetch != GUEST_USER_ID) {
+    final userIdForFetch = userId.isEmpty ? guestUserId : userId;
+    if (userIdForFetch.isEmpty && userIdForFetch != guestUserId) {
       logger.w("HydrationProvider: User ID is empty for date range stream, returning empty stream.");
       return Stream.value([]);
     }
@@ -148,8 +148,8 @@ class HydrationProvider with ChangeNotifier {
 
   Future<void> addHydrationEntry(double amountMl, {DateTime? entryTime, String? notes, String? source}) async {
     if (_isDisposed) return;
-    final userIdForAction = _currentUserId ?? GUEST_USER_ID;
-    if (userIdForAction.isEmpty && userIdForAction != GUEST_USER_ID) {
+    final userIdForAction = _currentUserId ?? guestUserId;
+    if (userIdForAction.isEmpty && userIdForAction != guestUserId) {
       _actionStatus = HydrationActionStatus.error;
       _errorMessage = "User not authenticated or guest scope not identified.";
       _safeNotifyListeners();
@@ -189,8 +189,8 @@ class HydrationProvider with ChangeNotifier {
 
   Future<void> updateHydrationEntry(HydrationEntry entry) async {
     if (_isDisposed) return;
-    final userIdForAction = _currentUserId ?? GUEST_USER_ID;
-    if (userIdForAction.isEmpty && userIdForAction != GUEST_USER_ID) {
+    final userIdForAction = _currentUserId ?? guestUserId;
+    if (userIdForAction.isEmpty && userIdForAction != guestUserId) {
       _actionStatus = HydrationActionStatus.error;
       _errorMessage = "User not authenticated or guest scope not identified.";
       _safeNotifyListeners();
@@ -222,8 +222,8 @@ class HydrationProvider with ChangeNotifier {
 
   Future<void> deleteHydrationEntry(HydrationEntry entryToDelete) async {
     if (_isDisposed) return;
-    final userIdForAction = _currentUserId ?? GUEST_USER_ID;
-    if (userIdForAction.isEmpty && userIdForAction != GUEST_USER_ID) {
+    final userIdForAction = _currentUserId ?? guestUserId;
+    if (userIdForAction.isEmpty && userIdForAction != guestUserId) {
       _actionStatus = HydrationActionStatus.error;
       _errorMessage = "User not authenticated or guest scope not identified.";
       _safeNotifyListeners();

--- a/lib/src/presentation/screens/auth/login_screen.dart
+++ b/lib/src/presentation/screens/auth/login_screen.dart
@@ -60,7 +60,7 @@ class _LoginScreenState extends State<LoginScreen> {
           decoration: BoxDecoration( // Optional: Add a subtle gradient or background image
             gradient: LinearGradient(
               colors: [
-                theme.colorScheme.primaryContainer.withOpacity(0.5), // Changed
+                theme.colorScheme.primaryContainer.withAlpha((255 * 0.5).round()), // Changed
                 theme.scaffoldBackgroundColor,
                 theme.scaffoldBackgroundColor,
               ],
@@ -116,7 +116,7 @@ class _LoginScreenState extends State<LoginScreen> {
                 CustomButton(
                   text: 'Skip login for now',
                   onPressed: _skipLogin,
-                  backgroundColor: theme.colorScheme.secondaryContainer.withOpacity(0.7), // Changed
+                  backgroundColor: theme.colorScheme.secondaryContainer.withAlpha((255 * 0.7).round()), // Changed
                   textColor: theme.colorScheme.onSecondaryContainer, // Changed
                 ),
                 const Spacer(flex: 1),

--- a/lib/src/presentation/screens/home/add_water_log_screen.dart
+++ b/lib/src/presentation/screens/home/add_water_log_screen.dart
@@ -76,6 +76,7 @@ class _AddWaterLogScreenState extends State<AddWaterLogScreen> {
         initialTime: TimeOfDay.fromDateTime(_selectedDateTime),
       );
       if (pickedTime != null) {
+        if (!mounted) return;
         setState(() {
           _selectedDateTime = DateTime(
             pickedDate.year,
@@ -201,7 +202,7 @@ class _AddWaterLogScreenState extends State<AddWaterLogScreen> {
                     Navigator.of(context).pop();
                   } catch (e) {
                     logger.e("Error deleting log from AddWaterLogScreen: $e");
-                    if (!mounted) return;
+                    if (!mounted) return; // Added check for catch block
                     AppUtils.hideLoadingDialog(context);
                   }
                 }

--- a/lib/src/presentation/screens/home/main_hydration_view.dart
+++ b/lib/src/presentation/screens/home/main_hydration_view.dart
@@ -53,7 +53,7 @@ class MainHydrationView extends StatelessWidget {
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                Icon(Icons.local_drink_outlined, size: 60.sp, color: Theme.of(context).colorScheme.onSurfaceVariant.withOpacity(0.7)), // Changed
+                Icon(Icons.local_drink_outlined, size: 60.sp, color: Theme.of(context).colorScheme.onSurfaceVariant.withAlpha((255 * 0.7).round())), // Changed
                 SizedBox(height: 16.h),
                 Text(
                   'No water logged yet for today.',
@@ -62,7 +62,7 @@ class MainHydrationView extends StatelessWidget {
                 SizedBox(height: 8.h),
                 Text(
                   'Tap the (+) button to add your first drink!',
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: Theme.of(context).colorScheme.onSurfaceVariant.withOpacity(0.8)), // Changed
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: Theme.of(context).colorScheme.onSurfaceVariant.withAlpha((255 * 0.8).round())), // Changed
                   textAlign: TextAlign.center,
                 ),
               ],

--- a/lib/src/presentation/screens/profile/profile_screen.dart
+++ b/lib/src/presentation/screens/profile/profile_screen.dart
@@ -13,7 +13,7 @@ import 'package:minum/src/presentation/widgets/common/custom_button.dart';
 import 'package:minum/src/presentation/widgets/common/custom_text_field.dart';
 import 'package:provider/provider.dart';
 import 'package:minum/main.dart'; // For logger
-import 'package:minum/src/data/repositories/local/local_hydration_repository.dart' show GUEST_USER_ID;
+import 'package:minum/src/data/repositories/local/local_hydration_repository.dart' show guestUserId;
 
 class ProfileScreen extends StatefulWidget {
   const ProfileScreen({super.key});
@@ -223,7 +223,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
 
 
     final tempUserForCalc = UserModel(
-      id: userProvider.userProfile?.id ?? GUEST_USER_ID,
+      id: userProvider.userProfile?.id ?? guestUserId,
       createdAt: userProvider.userProfile?.createdAt ?? DateTime.now(),
       displayName: _displayNameController.text.trim(),
       weightKg: double.tryParse(_weightController.text.trim()),

--- a/lib/src/presentation/screens/stats/hydration_history_screen.dart
+++ b/lib/src/presentation/screens/stats/hydration_history_screen.dart
@@ -14,9 +14,8 @@ import 'package:minum/src/presentation/providers/user_provider.dart';
 import 'package:minum/src/presentation/widgets/common/custom_button.dart';
 import 'package:provider/provider.dart';
 import 'package:fl_chart/fl_chart.dart';
-import 'package:minum/src/core/constants/app_colors.dart';
 import 'package:minum/main.dart';
-import 'package:minum/src/data/repositories/local/local_hydration_repository.dart' show GUEST_USER_ID;
+import 'package:minum/src/data/repositories/local/local_hydration_repository.dart' show guestUserId;
 
 
 enum HistoryViewType { weekly, monthly }
@@ -64,7 +63,7 @@ class _HydrationHistoryScreenState extends State<HydrationHistoryScreen> {
     if (loggedInUserId != null) {
       _currentDataScopeId = loggedInUserId;
     } else {
-      _currentDataScopeId = GUEST_USER_ID;
+      _currentDataScopeId = guestUserId;
     }
     _fetchHistoryData();
   }
@@ -73,7 +72,7 @@ class _HydrationHistoryScreenState extends State<HydrationHistoryScreen> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     final userProvider = Provider.of<UserProvider>(context);
-    final newScopeId = userProvider.userProfile?.id ?? GUEST_USER_ID;
+    final newScopeId = userProvider.userProfile?.id ?? guestUserId;
 
     if (newScopeId != _currentDataScopeId) {
       logger.d("HydrationHistoryScreen: Data scope changed from $_currentDataScopeId to $newScopeId. Re-fetching data.");
@@ -306,7 +305,7 @@ class _HydrationHistoryScreenState extends State<HydrationHistoryScreen> {
   Widget _buildLoginToSyncPrompt(BuildContext context) {
     final theme = Theme.of(context);
     return Container(
-      color: theme.colorScheme.primaryContainer.withOpacity(0.3), // Changed
+      color: theme.colorScheme.primaryContainer.withAlpha((255 * 0.3).round()), // Changed
       padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 12.h),
       child: Row(
         children: [
@@ -337,7 +336,7 @@ class _HydrationHistoryScreenState extends State<HydrationHistoryScreen> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(Icons.no_drinks_outlined, size: 70.sp, color: theme.colorScheme.onSurfaceVariant.withOpacity(0.6)), // Use theme
+            Icon(Icons.no_drinks_outlined, size: 70.sp, color: theme.colorScheme.onSurfaceVariant.withAlpha((255 * 0.6).round())), // Use theme
             SizedBox(height: 20.h),
             Text(
               AppStrings.noDataAvailable,
@@ -349,7 +348,7 @@ class _HydrationHistoryScreenState extends State<HydrationHistoryScreen> {
               isLoggedIn
                   ? 'No hydration logs found for the selected period.'
                   : 'Log some water to see your history here. Log in to sync across devices!',
-              style: theme.textTheme.bodyMedium?.copyWith(color: theme.colorScheme.onSurfaceVariant.withOpacity(0.8)),
+              style: theme.textTheme.bodyMedium?.copyWith(color: theme.colorScheme.onSurfaceVariant.withAlpha((255 * 0.8).round())),
               textAlign: TextAlign.center,
             ),
             if (!isLoggedIn) SizedBox(height: 20.h),
@@ -505,7 +504,7 @@ class _HydrationHistoryScreenState extends State<HydrationHistoryScreen> {
               show: true,
               drawVerticalLine: false,
               horizontalInterval: (maxY / 5).ceilToDouble() > 0 ? (maxY / 5).ceilToDouble() : 1,
-              getDrawingHorizontalLine: (value) => FlLine(color: theme.colorScheme.outlineVariant.withOpacity(0.5), strokeWidth: 0.5), // Changed
+              getDrawingHorizontalLine: (value) => FlLine(color: theme.colorScheme.outlineVariant.withAlpha((255 * 0.5).round()), strokeWidth: 0.5), // Changed
             ),
           ),
         ),

--- a/lib/src/presentation/widgets/home/daily_progress_card.dart
+++ b/lib/src/presentation/widgets/home/daily_progress_card.dart
@@ -2,7 +2,6 @@
 import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
-import 'package:minum/src/core/constants/app_colors.dart';
 import 'package:minum/src/data/models/user_model.dart'; // For MeasurementUnit
 import 'package:minum/src/core/utils/app_utils.dart'; // For formatting amount
 


### PR DESCRIPTION
This commit incorporates several changes to address lint warnings and update deprecated code:

1.  **Updated Material 3 ColorScheme Definitions:** In `lib/src/core/theme/app_theme.dart`:
    - Replaced deprecated `background` key with `surface` in ColorScheme definitions, using the color previously assigned to `background`.
    - Replaced deprecated `onBackground` key with `onSurface` in ColorScheme definitions, using the color previously assigned to `onBackground`.
    - (Previous commit had already updated `surfaceVariant` to `surfaceContainerHighest`).

2.  **Corrected Constant Naming:** Renamed `GUEST_USER_ID` to `guestUserId` in `lib/src/data/repositories/local/local_hydration_repository.dart` and updated all its usages across the codebase to adhere to `constant_identifier_names` lint rule.

3.  **Addressed `use_build_context_synchronously`:** Added/verified `mounted` checks before `BuildContext` usage after async gaps in `lib/src/presentation/screens/home/add_water_log_screen.dart`. (You have requested to defer any further subtle warnings on this rule for a future session).

4.  **Removed Unused Imports:** Deleted unused imports of `app_colors.dart` from `lib/src/presentation/screens/stats/hydration_history_screen.dart` and `lib/src/presentation/widgets/home/daily_progress_card.dart`.

Note: This commit builds upon a previous commit "flutter-updates-deprecations" which already handled `withOpacity` replacements and initial `surfaceVariant` updates in the theme.