### PR TITLE
Here's the revised message:

### DIFF
--- a/FLUTTER_SETUP_README.md
+++ b/FLUTTER_SETUP_README.md
@@ -1,0 +1,40 @@
+# Flutter Environment Setup Script
+
+This repository contains a script to automate the setup of a Flutter development environment on Linux.
+
+## Setup Script
+
+The main script is `setup_flutter_env.sh`.
+
+### Usage
+
+1.  **Clone the repository or download the script:**
+    If you've cloned the repository, navigate to its directory. If you've only downloaded `setup_flutter_env.sh`, make sure you're in the directory where you saved it.
+
+2.  **Run the script:**
+    Open your terminal and execute the script using the following command:
+    ```bash
+    ./setup_flutter_env.sh
+    ```
+    The script will:
+    *   Update your system's package lists.
+    *   Install necessary dependencies (like `curl`, `git`, `unzip`, etc.).
+    *   Download the Flutter SDK (version 3.32.0-stable for Linux).
+    *   Extract the Flutter SDK into a `flutter` directory in the current location.
+    *   Temporarily add the Flutter `bin` directory to your system's PATH for the current terminal session.
+    *   Enable Flutter web development.
+    *   Run `flutter doctor` to verify the setup.
+
+3.  **Permanent PATH Configuration (Important):**
+    The script will print instructions on how to make the Flutter PATH modification permanent. This usually involves adding a line like `export PATH="$PATH:/path/to/your/flutter/bin"` to your shell's configuration file (e.g., `~/.bashrc`, `~/.zshrc`). Follow the instructions provided by the script to ensure Flutter commands are available in all future terminal sessions.
+
+    For example, if you ran the script from `/home/user/dev/flutter_setup`, the line to add would be:
+    `export PATH="$PATH:/home/user/dev/flutter_setup/flutter/bin"`
+
+4.  **Project Dependencies:**
+    After running the setup script, navigate to your specific Flutter project directory and run `flutter pub get` to fetch project-specific dependencies.
+
+## Note
+
+*   The script uses `sudo` for package installation, so it may ask for your password.
+*   The Flutter SDK will be downloaded and extracted into a `flutter` subdirectory within the directory where you run the script.

--- a/setup_flutter_env.sh
+++ b/setup_flutter_env.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+echo "Starting Flutter environment setup..."
+
+# Update package lists
+echo "Updating package lists..."
+sudo apt-get update
+
+# Install system dependencies
+echo "Installing system dependencies (curl, git, unzip, xz-utils, zip, libglu1-mesa)..."
+sudo apt-get install -y curl git unzip xz-utils zip libglu1-mesa
+
+# Download Flutter
+FLUTTER_SDK_URL="https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.32.0-stable.tar.xz"
+FLUTTER_TARBALL="flutter_linux_3.32.0-stable.tar.xz"
+echo "Downloading Flutter SDK from $FLUTTER_SDK_URL..."
+curl -O $FLUTTER_SDK_URL
+
+# Extract Flutter
+echo "Extracting Flutter SDK to ./flutter..."
+tar xf $FLUTTER_TARBALL
+
+# Add Flutter to PATH for the current session
+echo "Adding Flutter to PATH for the current session..."
+export PATH="$PATH:`pwd`/flutter/bin"
+echo "Flutter PATH set for current session. To make it permanent, add the following line to your ~/.bashrc or ~/.zshrc:"
+echo 'export PATH="$PATH:'`pwd`'/flutter/bin"'
+
+
+# Enable Flutter web
+echo "Enabling Flutter web..."
+`pwd`/flutter/bin/flutter config --enable-web
+
+# Run Flutter doctor
+echo "Running Flutter doctor..."
+`pwd`/flutter/bin/flutter doctor
+
+# Placeholder for getting project dependencies
+echo "---------------------------------------------------------------------"
+echo "Flutter setup complete."
+echo "To get project-specific dependencies, navigate to your Flutter project directory and run:"
+echo "flutter pub get"
+echo "---------------------------------------------------------------------"


### PR DESCRIPTION
Fix: Restore original README.md and rename Flutter setup README

The previous commit inadvertently overwrote the existing README.md with instructions for the Flutter setup script.

This commit rectifies that by:
1. Renaming the Flutter setup instructions file from README.md to FLUTTER_SETUP_README.md.
2. Restoring the original README.md from the commit prior to the overwrite.